### PR TITLE
Authorization for commissions

### DIFF
--- a/app/controllers/commissions_controller.rb
+++ b/app/controllers/commissions_controller.rb
@@ -1,5 +1,6 @@
 class CommissionsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
+  before_action :correct_user,       except: [:index, :show, :new, :create]
 
   def index
     @commissions = Commission.all
@@ -41,7 +42,7 @@ class CommissionsController < ApplicationController
 
   def destroy
     Commission.find(params[:id]).destroy
-    redirect_to 'index'
+    redirect_to commissions_url
   end
 
   # Starting and finishing methods
@@ -88,5 +89,13 @@ class CommissionsController < ApplicationController
       params.require(:commission).permit(:title, :description, :started,
                                          :finished, :started_at, :finished_at,
                                           files: [])
+    end
+
+    def correct_user
+      @commission = current_user.commissions.find_by(id: params[:id])
+      if @commission.nil?
+        flash[:warning] = "You are not authorized to perform this action."
+        redirect_to root_url
+      end
     end
 end

--- a/app/controllers/commissions_controller.rb
+++ b/app/controllers/commissions_controller.rb
@@ -1,4 +1,6 @@
 class CommissionsController < ApplicationController
+  before_action :authenticate_user!, except: [:index, :show]
+
   def index
     @commissions = Commission.all
   end
@@ -13,6 +15,7 @@ class CommissionsController < ApplicationController
 
   def create
     @commission = Commission.new(commission_params)
+    @commission.user = current_user
 
     if @commission.valid?
       @commission.save

--- a/app/models/commission.rb
+++ b/app/models/commission.rb
@@ -1,4 +1,6 @@
 class Commission < ApplicationRecord
+  belongs_to :user
+
   validates :title, presence: true, length: { in: 3..128 }
 
   # File uploads through Active Storage

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,8 @@ class User < ApplicationRecord
   validates :name,     presence: true
   validates :uid,      presence: true, uniqueness: true
 
+  has_many :commissions
+
   def self.from_omniauth(auth)
     user = find_or_initialize_by(uid: auth.uid, provider: auth.provider)
 

--- a/app/views/commissions/index.html.erb
+++ b/app/views/commissions/index.html.erb
@@ -4,6 +4,10 @@
   <h4><%= link_to c.title, c %></h4>
 
   <p>
+    <%= c.user.username if c.user %>
+  </p>
+
+  <p>
     <%= c.description %>
   </p>
 

--- a/app/views/commissions/show.html.erb
+++ b/app/views/commissions/show.html.erb
@@ -27,6 +27,8 @@
       <%= link_to "Mark as finished", commission_finish_url(@c), method: :patch %>
     <% end %>
   <% end %>
+
+  <%= link_to "Delete commission", @c, method: :delete %>
 </p>
 
 <p>

--- a/db/migrate/20200520154038_add_user_id_to_commissions.rb
+++ b/db/migrate/20200520154038_add_user_id_to_commissions.rb
@@ -1,0 +1,6 @@
+class AddUserIdToCommissions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :commissions, :user_id, :integer
+    add_index  :commissions, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_16_171314) do
+ActiveRecord::Schema.define(version: 2020_05_20_154038) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -42,11 +42,13 @@ ActiveRecord::Schema.define(version: 2020_05_16_171314) do
     t.datetime "finished_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "user_id"
     t.index ["finished"], name: "index_commissions_on_finished"
     t.index ["finished_at"], name: "index_commissions_on_finished_at"
     t.index ["started"], name: "index_commissions_on_started"
     t.index ["started_at"], name: "index_commissions_on_started_at"
     t.index ["title"], name: "index_commissions_on_title"
+    t.index ["user_id"], name: "index_commissions_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Commissions now belong to users, who can only perform administrative tasks on commissions that belong to them. Not signed in users cannot create new commissions or update existing ones.