### PR TITLE
Private commissions

### DIFF
--- a/app/controllers/commissions_controller.rb
+++ b/app/controllers/commissions_controller.rb
@@ -1,6 +1,7 @@
 class CommissionsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :correct_user,       except: [:index, :show, :new, :create]
+  before_action :private_filter,     only:    :show
 
   def index
     @commissions = Commission.all
@@ -96,6 +97,17 @@ class CommissionsController < ApplicationController
       if @commission.nil?
         flash[:warning] = "You are not authorized to perform this action."
         redirect_to root_url
+      end
+    end
+
+    def private_filter
+      @commission = Commission.find(params[:id])
+
+      if @commission.private?
+        unless user_signed_in? && current_user == @commission.user
+          flash[:warning] = "This commission is marked private, only the uploader can access it."
+          redirect_to commissions_url
+        end
       end
     end
 end

--- a/app/controllers/commissions_controller.rb
+++ b/app/controllers/commissions_controller.rb
@@ -86,9 +86,9 @@ class CommissionsController < ApplicationController
 
   private
     def commission_params
-      params.require(:commission).permit(:title, :description, :started,
-                                         :finished, :started_at, :finished_at,
-                                          files: [])
+      params.require(:commission).permit(:title,    :description, :started,
+                                         :finished, :started_at,  :finished_at,
+                                         :private,   files: [])
     end
 
     def correct_user

--- a/app/views/commissions/edit.html.erb
+++ b/app/views/commissions/edit.html.erb
@@ -18,6 +18,9 @@
   <%= f.label :finished_at %>
   <%= f.date_field :finished_at %>
 
+  <%= f.label :private %>
+  <%= f.check_box :private %>
+
   <%= f.submit %>
 
 <% end %>

--- a/app/views/commissions/index.html.erb
+++ b/app/views/commissions/index.html.erb
@@ -1,7 +1,12 @@
 <h1>Commissions</h1>
 
 <% @commissions.each do |c| %>
-  <h4><%= link_to c.title, c %></h4>
+  <h4>
+    <%= link_to c.title, c %>
+    <% if c.private? %>
+      <span class="uk-label">Private</span>
+    <% end %>
+  </h4>
 
   <p>
     <%= c.user.username if c.user %>

--- a/app/views/commissions/new.html.erb
+++ b/app/views/commissions/new.html.erb
@@ -21,6 +21,9 @@
   <%= f.label :files %>
   <%= f.file_field :files, multiple: true %>
 
+  <%= f.label :private %>
+  <%= f.check_box :private %>
+
   <%= f.submit %>
 
 <% end %>

--- a/app/views/commissions/show.html.erb
+++ b/app/views/commissions/show.html.erb
@@ -1,5 +1,8 @@
 <h1>
   <%= @c.title %>
+  <% if @c.private? %>
+    <span class="uk-label">Private</span>
+  <% end %>
 </h1>
 <p>
   <%= @c.description %>

--- a/app/views/commissions/show.html.erb
+++ b/app/views/commissions/show.html.erb
@@ -31,6 +31,8 @@
     <% end %>
   <% end %>
 
+  <%= link_to "Edit commission", edit_commission_url(@c) %>
+
   <%= link_to "Delete commission", @c, method: :delete %>
 </p>
 

--- a/db/migrate/20200521210004_add_private_to_commissions.rb
+++ b/db/migrate/20200521210004_add_private_to_commissions.rb
@@ -1,0 +1,5 @@
+class AddPrivateToCommissions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :commissions, :private, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_20_154038) do
+ActiveRecord::Schema.define(version: 2020_05_21_210004) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 2020_05_20_154038) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "user_id"
+    t.boolean "private", default: false
     t.index ["finished"], name: "index_commissions_on_finished"
     t.index ["finished_at"], name: "index_commissions_on_finished_at"
     t.index ["started"], name: "index_commissions_on_started"


### PR DESCRIPTION
Commissions have a private boolean, allowing their owner to mark them as private. Private commissions cannot be viewed by anyone other than the uploader. They are marked as private in the index and show pages, but still show up (filtering is more something for #9)

This closes #8