### PR TITLE
Commissions#index only shows current user's commissions

### DIFF
--- a/app/controllers/commissions_controller.rb
+++ b/app/controllers/commissions_controller.rb
@@ -1,10 +1,10 @@
 class CommissionsController < ApplicationController
-  before_action :authenticate_user!, except: [:index, :show]
+  before_action :authenticate_user!, except: [:show                       ]
   before_action :correct_user,       except: [:index, :show, :new, :create]
-  before_action :private_filter,     only:    :show
+  before_action :private_filter,     only:   [:show                       ]
 
   def index
-    @commissions = Commission.all
+    @commissions = current_user.commissions
   end
 
   def show

--- a/app/views/commissions/index.html.erb
+++ b/app/views/commissions/index.html.erb
@@ -1,30 +1,37 @@
 <h1>Commissions</h1>
 
-<% @commissions.each do |c| %>
-  <h4>
-    <%= link_to c.title, c %>
-    <% if c.private? %>
-      <span class="uk-label">Private</span>
-    <% end %>
-  </h4>
+<% unless @commissions.empty? %>
+  <% @commissions.each do |c| %>
+    <h4>
+      <%= link_to c.title, c %>
+      <% if c.private? %>
+        <span class="uk-label">Private</span>
+      <% end %>
+    </h4>
 
+    <p>
+      <%= c.user.username if c.user %>
+    </p>
+
+    <p>
+      <%= c.description %>
+    </p>
+
+    <p>
+      <% if c.finished? %>
+        <%= "Finished" %>
+      <% elsif c.started? %>
+        <%= "Started" %>
+      <% else %>
+        <%= "Not started" %>
+      <% end %>
+    </p>
+
+    <hr>
+  <% end %>
+<% else %>
   <p>
-    <%= c.user.username if c.user %>
+    You don't have any commissions yet. Why not
+    <%= link_to "create a new one?", new_commission_url %>
   </p>
-
-  <p>
-    <%= c.description %>
-  </p>
-
-  <p>
-    <% if c.finished? %>
-      <%= "Finished" %>
-    <% elsif c.started? %>
-      <%= "Started" %>
-    <% else %>
-      <%= "Not started" %>
-    <% end %>
-  </p>
-
-  <hr>
 <% end %>


### PR DESCRIPTION
Remove the public list of commissions and make it only show the current user's commissions, complete with a placeholder in case there are none and a redirect to sign in if necessary. Fixes #9.