### PR TITLE
Commission thumbnails

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,6 +18,4 @@ module ApplicationHelper
       type
     end
   end
-
-  # Helper method for thumbnail or filler
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,4 +18,6 @@ module ApplicationHelper
       type
     end
   end
+
+  # Helper method for thumbnail or filler
 end

--- a/app/models/commission.rb
+++ b/app/models/commission.rb
@@ -33,4 +33,12 @@ class Commission < ApplicationRecord
       self.save
     end
   end
+
+  def thumbnail
+    if self.files.attached?
+      self.files.first.variant(resize_to_limit: [200, 200]).processed.image
+    else
+      false
+    end
+  end
 end

--- a/app/views/commissions/index.html.erb
+++ b/app/views/commissions/index.html.erb
@@ -2,32 +2,34 @@
 
 <% unless @commissions.empty? %>
   <% @commissions.each do |c| %>
-    <h4>
-      <%= link_to c.title, c %>
-      <% if c.private? %>
-        <span class="uk-label">Private</span>
-      <% end %>
-    </h4>
-
-    <p>
-      <%= c.user.username if c.user %>
-    </p>
-
-    <p>
-      <%= c.description %>
-    </p>
-
-    <p>
-      <% if c.finished? %>
-        <%= "Finished" %>
-      <% elsif c.started? %>
-        <%= "Started" %>
-      <% else %>
-        <%= "Not started" %>
-      <% end %>
-    </p>
-
-    <hr>
+    <div class="uk-card uk-card-default">
+      <div class="uk-card-body">
+        <%= image_tag c.thumbnail if c.files.attached? %>
+      </div>
+      <div class="uk-card-footer">
+        <h4>
+          <%= link_to c.title, c %>
+          <% if c.private? %>
+            <span class="uk-label">Private</span>
+          <% end %>
+        </h4>
+        <p>
+          <%= c.user.username %>
+        </p>
+        <p>
+          <%= c.description %>
+        </p>
+        <p>
+          <% if c.finished? %>
+            <%= "Finished" %>
+          <% elsif c.started? %>
+            <%= "Started" %>
+          <% else %>
+            <%= "Not started" %>
+          <% end %>
+        </p>
+      </div>
+    </div>
   <% end %>
 <% else %>
   <p>

--- a/app/views/folders/show.html.erb
+++ b/app/views/folders/show.html.erb
@@ -15,6 +15,7 @@
 <% unless @folder.commissions.empty? %>
   <h4> Commissions in this folder:</h4>
   <% @folder.commissions.each do |c| %>
+    <%= image_tag c.thumbnail if c.files.attached? %>
     <p>
       <%= link_to c.title, folder_commission_url(@folder, c) %>
       <% if c.private? %>


### PR DESCRIPTION
Lazy generate 200x200 thumbnails of every commission's first image for use in indexes/folders. Now that we know it works like this, it should also be easy to use this for other purposes, like navigation elements. Closes #26. 