### PR TITLE
Implement admins

### DIFF
--- a/db/migrate/20200527220027_add_admins_to_users.rb
+++ b/db/migrate/20200527220027_add_admins_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminsToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_26_232439) do
+ActiveRecord::Schema.define(version: 2020_05_27_220027) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -85,6 +85,7 @@ ActiveRecord::Schema.define(version: 2020_05_26_232439) do
     t.string "username"
     t.string "name"
     t.string "image_url"
+    t.boolean "admin", default: false
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -51,6 +51,13 @@ RSpec.describe User, type: :model do
     end
   end
 
+  context "admin" do
+    it "should be false by default" do
+      user = create(:user)
+      expect(user.admin?).to be false
+    end
+  end
+
   context "commissions" do
     it "should return a user's commissions" do
       user = create(:user)


### PR DESCRIPTION
Enable users to be marked as admins, allowing them to bypass private and correct user filters, enabling them to edit and delete other users' data. Later on they should also be able to ban users (#40). Closes #12.

Things to do before this PR is done:

- [x] Add admin boolean to the database

- [x] Update user model specs

- [x] Change filters in commissions controller

- [x] Change filters in folders controller

- [x] Update folder request specs